### PR TITLE
Fix syntax error in conductor-init.sh heredoc

### DIFF
--- a/conductor-init.sh
+++ b/conductor-init.sh
@@ -306,8 +306,11 @@ combined_roles = list(set(current_roles + new_roles))
 config['roles']['specialized'] = combined_roles
 with open('.conductor/config.yaml', 'w') as f:
     yaml.dump(config, f, default_flow_style=False)
-print(f'✅ Roles added: {', '.join(new_roles)}')
-EOF || echo -e "${YELLOW}⚠️ Could not update roles automatically.${NC}"
+print(f'✅ Roles added: {", ".join(new_roles)}')
+EOF
+            if [ $? -ne 0 ]; then
+                echo -e "${YELLOW}⚠️ Could not update roles automatically.${NC}"
+            fi
         else
             echo -e "${YELLOW}⚠️ No valid selections made.${NC}"
         fi


### PR DESCRIPTION
## Summary
- Fixed "unexpected end of file" syntax error at line 429 in conductor-init.sh
- Corrected f-string quote mismatch in Python print statement 
- Moved heredoc EOF delimiter to its own line per bash requirements

## Problem
The installer script was failing with:
```
/dev/fd/11: line 429: syntax error: unexpected end of file
```

This occurred after the role configuration step.

## Solution
The issue was caused by two problems:
1. A Python f-string had mismatched quotes: `print(f'✅ Roles added: {', '.join(new_roles)}')`
2. The heredoc EOF delimiter was not on its own line (had `|| echo ...` after it)

Fixed by:
- Changing the f-string to use double quotes inside: `{", ".join(new_roles)}`
- Moving EOF to its own line and using proper error handling with `if [ $? -ne 0 ]`

## Test plan
- [x] Verified bash syntax passes: `bash -n conductor-init.sh`
- [ ] Test the installer script end-to-end
- [ ] Verify role addition functionality works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)