### PR TITLE
Fix installer UX: Move all file modifications before commit

### DIFF
--- a/conductor-init.sh
+++ b/conductor-init.sh
@@ -184,24 +184,7 @@ fi
 echo -e "${GREEN}✅ Setup complete.${NC}"
 echo ""
 
-# Step 5: Auto-commit generated files (with user consent)
-echo -e "${YELLOW}📝 Committing generated files to Git...${NC}"
-git add .conductor .github setup.py requirements.txt pyproject.toml VERSION 2>/dev/null
-if git diff --staged --quiet; then
-    echo -e "${GREEN}✅ No changes to commit (files already in Git).${NC}"
-else
-    read -p "Commit these changes automatically? [Y/n]: " -n 1 -r
-    echo ""
-    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
-        git commit -m "Initialize Code Conductor setup" || echo -e "${YELLOW}⚠️ Commit failed.${NC}"
-        echo -e "${GREEN}✅ Changes committed.${NC}"
-    else
-        echo -e "${YELLOW}⚠️ Skipping commit. Remember to commit manually.${NC}"
-    fi
-fi
-echo ""
-
-# Step 6: Interactive Role Configuration (improved: numbered menu)
+# Step 5: Interactive Role Configuration (improved: numbered menu)
 echo -e "${YELLOW}🎭 Configuring agent roles...${NC}"
 
 # Read detected stacks from config
@@ -319,7 +302,7 @@ EOF
     fi
 fi
 
-# Step 7: Seed Demo Tasks
+# Step 6: Seed Demo Tasks
 echo ""
 echo -e "${YELLOW}📝 Creating demo tasks...${NC}"
 
@@ -365,6 +348,24 @@ else:
     print('✅ Tasks already exist')
 " || echo -e "${YELLOW}⚠️ Could not create demo tasks.${NC}"
 fi
+
+# Step 7: Auto-commit generated files (with user consent)
+echo ""
+echo -e "${YELLOW}📝 Committing generated files to Git...${NC}"
+git add .conductor .github setup.py requirements.txt pyproject.toml VERSION 2>/dev/null
+if git diff --staged --quiet; then
+    echo -e "${GREEN}✅ No changes to commit (files already in Git).${NC}"
+else
+    read -p "Commit these changes automatically? [Y/n]: " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+        git commit -m "Initialize Code Conductor setup" || echo -e "${YELLOW}⚠️ Commit failed.${NC}"
+        echo -e "${GREEN}✅ Changes committed.${NC}"
+    else
+        echo -e "${YELLOW}⚠️ Skipping commit. Remember to commit manually.${NC}"
+    fi
+fi
+echo ""
 
 # Step 8: Launch Agent (improved: handle uncommitted changes)
 echo ""


### PR DESCRIPTION
## Summary
- Fixed confusing UX where uncommitted changes appeared immediately after initial commit
- Reorganized installer flow to perform all file modifications before the commit prompt
- Users now have a clean working directory when starting their first agent

## Problem
After running the installer and committing the initial setup, users were immediately faced with uncommitted changes when trying to start an agent:

```
Would you like to start a dev agent now? [Y/n]: y
🤖 Starting dev agent...
⚠️ Uncommitted changes detected.
Stash them automatically before starting agent? [Y/n]: 
```

The uncommitted changes were from the installer itself:
- Role configuration modifications to `.conductor/config.yaml`
- Demo task creation modifications to `.conductor/workflow-state.json`

## Solution
Reorganized the installer steps from:
```
Setup → Commit → Role Config → Demo Tasks → Launch Agent
```

To:
```
Setup → Role Config → Demo Tasks → Commit → Launch Agent
```

This ensures all file modifications happen before the commit, resulting in a clean working directory when the user starts their first agent.

## Test plan
- [ ] Run the installer in a fresh repo
- [ ] Verify role configuration happens before commit
- [ ] Verify demo tasks are created before commit
- [ ] Verify no uncommitted changes after commit
- [ ] Verify agent starts without stash prompt

🤖 Generated with [Claude Code](https://claude.ai/code)