### PR TITLE
Fix: Update validation script to check for conductor instead of bootstrap.sh

### DIFF
--- a/.conductor/scripts/validate-config.py
+++ b/.conductor/scripts/validate-config.py
@@ -259,7 +259,7 @@ def validate_scripts():
 
     # Required scripts
     required_scripts = [
-        "bootstrap.sh",
+        "conductor",
         "task-claim.py",
         "dependency-check.py",
         "health-check.py",


### PR DESCRIPTION
## Summary
Updates the validation script to check for the `conductor` script instead of the deprecated `bootstrap.sh`.

## Problem
After PR #22 removed the deprecated `bootstrap.sh` file, the CI/CD validation was failing because `validate-config.py` was still looking for it.

## Solution
Updated the required scripts list in `validate-config.py` to check for `conductor` instead of `bootstrap.sh`.

## Test Plan
- [x] Updated validation script
- [ ] CI/CD validation should now pass

This is a follow-up fix to PR #22 that cleaned up deprecated files.

🤖 Generated with [Claude Code](https://claude.ai/code)