### PR TITLE
Fix: Clarify token requirements and Python dependency scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ One command. 60 seconds. Done.
 bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh)
 ```
 
-The installer auto-detects your stack (React, Python, Go, etc.) and configures everything. No GitHub tokens. No complex setup.
+The installer auto-detects your stack (React, Python, Go, etc.) and configures everything. **No GitHub tokens needed. No complex setup.**
+
+✨ **What you get:**
+- ✅ GitHub Actions workflows that use built-in authentication
+- ✅ No manual token creation or repository secrets required
+- ✅ AI code reviews work automatically on all PRs
+- ✅ Language-agnostic setup (no Python CI/CD added to non-Python projects)
 
 **Or let Claude Code install it for you:**
 ```
@@ -65,6 +71,7 @@ gh issue create --label "conductor:task" --title "Add dark mode toggle"
 - [Stack Support](docs/STACK_SUPPORT.md) - Works with React, Vue, Python, Go, and more
 - [Architecture](docs/ARCHITECTURE.md) - How it all works under the hood
 - [AI Code Review](docs/AI_CODE_REVIEW.md) - Smart, opt-in PR reviews
+- [FAQ](docs/FAQ.md) - Common questions about tokens, Python, and workflows
 - [Troubleshooting](docs/TROUBLESHOOTING.md) - Common issues and solutions
 
 🚀 **[Power User Prompts](CLAUDE_CODE_PROMPT.md)** - Game-changing automation with Claude Code

--- a/conductor-init.sh
+++ b/conductor-init.sh
@@ -17,6 +17,9 @@ echo "=========================================="
 echo "This script will install Code Conductor into your current Git repository."
 echo "It will download necessary files and run the setup automatically."
 echo ""
+echo -e "${GREEN}✨ No GitHub Token Setup Required!${NC}"
+echo "Code Conductor uses GitHub's built-in authentication - no manual token needed."
+echo ""
 
 # Step 1: Prerequisite Checks
 echo -e "${YELLOW}🔍 Checking prerequisites...${NC}"
@@ -36,6 +39,8 @@ fi
 # Check for Python 3.9-3.12
 if ! command -v python3 >/dev/null 2>&1 || ! python3 -c "import sys; exit(0 if sys.version_info >= (3,9) and sys.version_info < (3,13) else 1)"; then
     echo -e "${RED}❌ Error: Python 3.9-3.12 is required. Please install Python 3.9, 3.10, 3.11, or 3.12.${NC}"
+    echo -e "${YELLOW}Note: Python is only needed for conductor scripts, NOT for your project's CI/CD.${NC}"
+    echo -e "${YELLOW}Code Conductor does NOT add Python-specific workflows to non-Python projects.${NC}"
     exit 1
 fi
 
@@ -323,6 +328,13 @@ if [ "$IS_UPGRADE" = false ]; then
 
     echo -e "${GREEN}✅ Setup complete.${NC}"
     echo ""
+    
+    # Emphasize no token requirement
+    echo -e "${GREEN}🔐 GitHub Integration Status:${NC}"
+    echo "  ✅ Workflows configured to use GitHub's built-in token"
+    echo "  ✅ No CONDUCTOR_GITHUB_TOKEN setup required"
+    echo "  ✅ AI code reviews will work automatically on PRs"
+    echo ""
 else
     echo -e "${GREEN}✅ Skipping setup - existing configuration preserved.${NC}"
     echo ""
@@ -583,7 +595,7 @@ case "$ENV_CHOICE" in
         echo "   • Conductor will handle task claiming and worktree setup automatically"
         echo "   • Use the built-in terminal for git operations"
         echo "   • AI code reviews happen automatically on PRs"
-        echo "   • No GitHub token setup needed—uses built-in authentication"
+        echo -e "   • ${GREEN}No GitHub token setup needed—uses built-in authentication${NC}"
         echo ""
         echo "📚 Learn more: https://conductor.build"
         ;;
@@ -661,7 +673,7 @@ if [ "$IS_UPGRADE" = true ]; then
     echo "  • Role definitions (.conductor/roles/)"
     echo "  • GitHub workflows (.github/workflows/)"
     echo "  • Setup and configuration tools"
-    echo "  • Token configuration (no manual setup needed)"
+    echo -e "  • ${GREEN}Token configuration (uses GitHub's built-in auth)${NC}"
     echo ""
     echo "✅ What was preserved:"
     echo "  • Your project configuration (.conductor/config.yaml)"
@@ -698,6 +710,8 @@ elif [ "$ENV_CHOICE" != "1" ]; then
     echo "  ✅ AI code-reviewer for all PRs"
     echo "  ✅ Specialized roles: ${CONFIGURED_ROLES}"
     echo "  ✅ Demo tasks ready to claim"
+    echo -e "  ${GREEN}✅ No GitHub token setup required${NC}"
+    echo -e "  ${GREEN}✅ No Python CI/CD workflows added${NC}"
     echo ""
     echo -e "${YELLOW}Quick Start Commands:${NC}"
     echo -e "  📋 View tasks:     ${GREEN}./conductor tasks${NC}"
@@ -725,7 +739,8 @@ else
     echo "  ✅ AI code-reviewer for all PRs"
     echo "  ✅ Specialized roles: ${CONFIGURED_ROLES}"
     echo "  ✅ Demo tasks ready in Conductor"
-    echo "  ✅ No GitHub token setup required"
+    echo -e "  ${GREEN}✅ No GitHub token setup required${NC}"
+    echo -e "  ${GREEN}✅ No Python CI/CD workflows added${NC}"
     echo ""
     echo "📚 Documentation: https://github.com/ryanmac/code-conductor"
     echo "🐛 Report issues: https://github.com/ryanmac/code-conductor/issues"

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,88 @@
+# Frequently Asked Questions
+
+## Do I need to set up a CONDUCTOR_GITHUB_TOKEN?
+
+**No!** Code Conductor uses GitHub's built-in authentication (`${{ github.token }}`) for all workflows. This token is automatically available in GitHub Actions with no setup required.
+
+You only need a Personal Access Token (PAT) if you want:
+- Higher API rate limits (5,000/hour vs 1,000/hour)
+- Cross-repository access
+- Ability to trigger other workflows
+
+For detailed token information, see [.conductor/GITHUB_TOKEN_SETUP.md](.conductor/GITHUB_TOKEN_SETUP.md).
+
+## Why does Code Conductor require Python?
+
+Python is required **only for the conductor orchestration scripts**, not for your project's CI/CD. Here's what this means:
+
+- ✅ **Required**: Python 3.9-3.12 to run conductor commands
+- ❌ **NOT added**: Python test runners (pytest)
+- ❌ **NOT added**: Python linters (flake8, black)
+- ❌ **NOT added**: Python security scanners (safety)
+- ❌ **NOT added**: Any Python-specific CI/CD workflows
+
+Your project's existing CI/CD remains unchanged. Code Conductor only adds three language-agnostic GitHub workflows for task orchestration.
+
+## Does Code Conductor add Python CI/CD to my JavaScript/TypeScript/Go project?
+
+**No!** Code Conductor is language-agnostic. It detects your project's technology stack and configures roles accordingly, but it does NOT add language-specific CI/CD workflows.
+
+The only workflows added are:
+1. `conductor.yml` - Task orchestration and health checks
+2. `conductor-cleanup.yml` - Stale worktree cleanup
+3. `pr-review.yml` - AI code reviews (if enabled)
+
+These workflows only run conductor scripts and do not test, lint, or build your code.
+
+## What if I see Python test failures in my CI?
+
+If you're seeing Python test failures like:
+```
+============================= test session starts ==============================
+collected 0 items
+============================ no tests ran in 0.02s =============================
+Error: Process completed with exit code 5.
+```
+
+This is NOT from Code Conductor. Check if:
+1. You accidentally copied CI workflows from the Code Conductor repository itself
+2. You have existing Python CI workflows in your project
+3. Another tool added Python-specific workflows
+
+Code Conductor's template workflows do not include any Python testing commands.
+
+## Can I use Code Conductor without installing Python?
+
+Currently, Python is required because the conductor scripts are written in Python. We chose Python for:
+- Maximum compatibility across all platforms
+- Easy installation via standard package managers
+- Reliable YAML and JSON processing
+- Strong GitHub API support
+
+Future versions may offer alternative implementations, but Python remains the most universal choice.
+
+## Do I need to manage Python dependencies for my non-Python project?
+
+No, the Python dependencies are isolated to Code Conductor's functionality:
+- `pyyaml` - For configuration file handling
+- Standard library modules only
+
+These are only used by conductor scripts and do not affect your project's dependencies.
+
+## How do I know which workflows were added by Code Conductor?
+
+Code Conductor only adds workflows from its templates:
+- `.github/workflows/conductor.yml`
+- `.github/workflows/conductor-cleanup.yml`
+- `.github/workflows/pr-review.yml` (if code-reviewer role is enabled)
+
+Any other workflows (especially those running pytest, flake8, etc.) are from other sources.
+
+## Can I remove the Python dependency from Code Conductor?
+
+The conductor scripts require Python to run. However, you can:
+1. Run agents from the Conductor app (macOS) which handles Python internally
+2. Use containerized environments where Python is pre-installed
+3. Install Python in your CI environment only (not locally)
+
+The Python requirement is minimal and doesn't affect your project's runtime or deployment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Welcome to the comprehensive Code Conductor documentation. This directory contai
 - [**Installation Guide**](INSTALLATION.md) - All installation methods and options
 - [**Usage Guide**](USAGE.md) - How to use Code Conductor effectively
 - [**Stack Support**](STACK_SUPPORT.md) - Supported technologies and frameworks
+- [**FAQ**](FAQ.md) - Frequently asked questions and clarifications
 
 ### Core Concepts
 - [**Architecture**](ARCHITECTURE.md) - System design and components


### PR DESCRIPTION
## Summary

This PR addresses important user feedback about confusion regarding GitHub token requirements and Python dependencies in Code Conductor. A user reported frustration about:
1. Having to manually set up a `CONDUCTOR_GITHUB_TOKEN` (which shouldn't be required)
2. Concern about Python workflows being added to their TypeScript project
3. Lack of clear documentation about these requirements

## Changes Made

### 1. Enhanced Installation Messaging
- Added prominent "No GitHub Token Setup Required\!" message at installer startup
- Clarified that Python is only needed for conductor scripts, NOT for CI/CD
- Added success confirmations emphasizing no token setup and no Python workflows

### 2. Documentation Improvements
- Created comprehensive FAQ (`docs/FAQ.md`) addressing:
  - Token requirements (none for most users\!)
  - Why Python is needed (orchestration only)
  - What workflows are actually added (language-agnostic only)
  - Common misconceptions about Python CI/CD
- Updated README.md to emphasize no-token setup
- Added FAQ to documentation index

### 3. Clarified Workflow Behavior
- Confirmed that template workflows use `${{ github.token }}` (built-in auth)
- Verified no Python-specific CI/CD workflows are added to projects
- Documented that only 3 language-agnostic workflows are installed

## User Impact

Users will now clearly understand that:
- ✅ No manual GitHub token creation or secrets setup required
- ✅ Code Conductor doesn't add Python test/lint workflows to non-Python projects  
- ✅ Python is only needed to run conductor commands, not for their project's CI/CD
- ✅ The system works out-of-the-box with GitHub's built-in authentication

## Testing

- Verified installer messages display correctly
- Confirmed workflows use built-in GitHub token
- Validated no Python CI workflows in templates
- Documentation renders properly

## Related Issues

Addresses user feedback about token setup confusion and Python workflow concerns.

🤖 Generated with [Claude Code](https://claude.ai/code)