### PR TITLE
feat: Add non-interactive installation mode for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,16 @@ The installer auto-detects your stack (React, Python, Go, etc.) and configures e
 - ✅ AI code reviews work automatically on all PRs
 - ✅ Language-agnostic setup (no Python CI/CD added to non-Python projects)
 
-**Or let Claude Code install it for you:**
+**For Claude Code (non-interactive):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh | bash -s -- --auto
+```
+
+**Or paste this prompt into Claude Code:**
 ```
 I need to move faster. Install Code Conductor into this project so we can run multiple Claude Code agents at once.
 
-Execute: bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh)
+Execute: curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh | bash -s -- --auto
 ```
 
 ## See It In Action

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -16,8 +16,40 @@ Run this in your existing project's root directory to download and install Code 
 bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh)
 ```
 
+### For Claude Code and Non-Interactive Environments
+
+Use the `--auto` flag for non-interactive installation (perfect for Claude Code):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh | bash -s -- --auto
+```
+
+### Installation Options
+
+The installer supports various command-line flags for customization:
+
+```bash
+# Show all available options
+bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh) --help
+
+# Common options:
+--auto                # Non-interactive mode with sensible defaults
+--upgrade             # Force upgrade even if already installed
+--reinstall           # Force fresh installation (removes existing config)
+--force               # Continue even when already at latest version
+--skip-examples       # Skip copying example configurations
+--skip-commit         # Skip auto-committing changes to Git
+--skip-agent-start    # Skip starting a dev agent after installation
+
+# Examples:
+curl -fsSL ... | bash -s -- --auto --upgrade        # Auto-upgrade
+curl -fsSL ... | bash -s -- --auto --skip-commit    # Install without committing
+```
+
+### Installation Notes
+
 - This method avoids cloning the full Code Conductor repo and is ideal for integrating into existing projects without repository pollution.
-- The script will prompt before overwriting any existing installation.
+- The script will prompt before overwriting any existing installation (in interactive mode).
 - **Security best practice:** Review the script at the raw URL before running.
 - **Pyenv users:** If Poetry install fails, switch to the Python version that has Poetry installed (e.g., `pyenv shell 3.10.13`) and re-run.
 


### PR DESCRIPTION
## Summary
- Added `--auto` flag for non-interactive installation, perfect for Claude Code
- Smart defaults that make sensible choices without user input
- Additional control flags for specific scenarios

## Problem

When installing Code Conductor from Claude Code, the installer would hang on interactive prompts, making the experience frustrating:
- Upgrade/reinstall/cancel choice
- Continue anyway when already at latest version  
- Example files prompt
- Auto-commit prompt
- Development environment selection
- Start agent prompt

Claude Code couldn't handle these interactive prompts effectively.

## Solution

Added command-line argument parsing with these options:
- `--auto` / `--non-interactive` - Run with sensible defaults
- `--upgrade` - Force upgrade even if already installed
- `--reinstall` - Force fresh installation
- `--force` - Continue even when already at latest version
- `--skip-examples` - Skip copying example configurations
- `--skip-commit` - Skip auto-committing changes
- `--skip-agent-start` - Skip starting dev agent
- `--help` - Show usage information

In auto mode, the installer:
- Defaults to upgrade for existing installations
- Copies examples for new installations
- Auto-commits changes
- Skips agent startup (better for CI environments)
- Provides clear feedback without waiting for input

## Usage

```bash
# Interactive (default)
bash <(curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh)

# Non-interactive (for Claude Code)
curl -fsSL https://raw.githubusercontent.com/ryanmac/code-conductor/main/conductor-init.sh | bash -s -- --auto

# With specific options
curl -fsSL ... | bash -s -- --auto --upgrade --skip-commit
```

## Test plan
- [x] Bash syntax check passes
- [x] Help command displays correctly
- [x] Documentation updated with new options
- [ ] CI checks pass
- [ ] Manual testing in various scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)