### PR TITLE
fix: Add critical [INIT] documentation map task to installer

### DIFF
--- a/conductor-init.sh
+++ b/conductor-init.sh
@@ -551,7 +551,51 @@ if [ "$IS_UPGRADE" = false ]; then
         EXISTING_TASKS=$(gh issue list -l 'conductor:task' --limit 10 --json number 2>/dev/null | jq length 2>/dev/null || echo "0")
         
         if [ "$EXISTING_TASKS" = "0" ]; then
-            echo "Creating demo GitHub Issues..."
+            echo "Creating initial tasks..."
+            
+            # Create critical documentation map task first
+            gh issue create \
+                --title "[INIT] Build documentation map and analyze codebase" \
+                --body "## Description
+This is the initial discovery task that analyzes the entire codebase to create a comprehensive documentation map. This map is essential for Code Conductor to understand the project structure and generate appropriate tasks.
+
+## Objective
+Create .conductor/documentation-map.yaml with:
+- Complete project analysis and structure mapping
+- Technology stack detection and validation
+- List of existing vs. missing documentation
+- Feature implementation status
+- Critical paths and dependencies
+- Proposed tasks based on project needs
+
+## Success Criteria
+- Documentation map created at .conductor/documentation-map.yaml
+- Project structure fully analyzed and documented
+- Technology stack properly identified
+- Missing documentation identified
+- Generate initial task proposals based on project state
+- Run generate-tasks-from-map.py to create follow-up tasks
+
+## Process
+1. Analyze entire codebase structure
+2. Detect all technologies, frameworks, and tools
+3. Identify existing documentation
+4. Map feature implementation status
+5. Create comprehensive YAML documentation map
+6. Generate missing documentation where possible
+7. Propose initial tasks based on findings
+
+## Priority
+This task has the highest priority as all other tasks depend on the documentation map for context.
+
+## Files to Create/Modify
+- .conductor/documentation-map.yaml (create)
+- .conductor/README.md (update if needed)
+- Project documentation files (as identified)" \
+                --label "conductor:task" \
+                --label "effort:large" \
+                --label "priority:high" \
+                2>/dev/null && echo "  ✅ Created critical task: [INIT] Build documentation map"
             
             # Create first demo task
             gh issue create \


### PR DESCRIPTION
## Summary
This PR addresses user feedback that the conductor-init.sh installer should create an initial discovery task for building the documentation map. Previously, the installer only created demo tasks without the critical [INIT] task needed to analyze the codebase.

## Problem
The user reported:
> "I ran the conductor-init.sh... However, I noticed it did NOT add an issue to prepare the documentation map. This is a new project, with barely any code or documentation, but it still should've build the documentation map. I expected it to create a critical issue (or otherwise highest priority) to build this map, and even generate missing documentation where possible."

## Solution
Modified `conductor-init.sh` to create a high-priority "[INIT] Build documentation map and analyze codebase" task during installation. This task:
- Has the highest priority as other tasks depend on it
- Provides detailed instructions for creating `.conductor/documentation-map.yaml`
- Includes objectives, success criteria, and process steps
- Instructs to run `generate-tasks-from-map.py` after completion

## Changes
- Updated the "Creating demo tasks" section to "Creating initial tasks"
- Added creation of the [INIT] documentation map task as the first issue
- Set appropriate labels: `conductor:task`, `effort:large`, `priority:high`
- Kept the existing demo tasks for additional starter work

## Testing
- Verified script syntax with `bash -n`
- Confirmed the new issue creation command is properly formatted
- Tested that the script maintains backward compatibility

## Impact
New Code Conductor installations will now properly initialize with the critical documentation map task, ensuring AI agents have the context they need to understand the project and generate appropriate follow-up tasks.

🤖 Generated with [Claude Code](https://claude.ai/code)